### PR TITLE
Removed 1 unnecessary stubbings in SubversionRepositoryStatusTest.java

### DIFF
--- a/src/test/java/hudson/scm/SubversionRepositoryStatusTest.java
+++ b/src/test/java/hudson/scm/SubversionRepositoryStatusTest.java
@@ -31,8 +31,6 @@ public class SubversionRepositoryStatusTest {
 
         // GIVEN: a disabled project
         final AbstractProject project = mock(AbstractProject.class);
-        when(project.isDisabled()).thenReturn(true);
-        
         JobProvider jobProvider = () -> Collections.singletonList(project);
         
         listener.setJobProvider(jobProvider);


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 unnecessary stubbing in `SubversionRepositoryStatusTest.shouldIgnoreDisabledJobs` is created but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.